### PR TITLE
Skip fields where timestamp is less than 0

### DIFF
--- a/bodyfile.go
+++ b/bodyfile.go
@@ -11,6 +11,9 @@ import (
 	"github.com/Knetic/govaluate"
 )
 
+// Timestamp lower limit: represents a -1 timestamp
+var smallestTime time.Time = time.Unix(-1, 0).UTC()
+
 // Entry represents one line of the bodyfile
 type Entry struct {
 	// MD5|name|inode|mode_as_string|UID|GID|size|atime|mtime|ctime|crtime
@@ -252,24 +255,24 @@ func (r *Reader) Slurp() (int, error) {
 			return 0, fmt.Errorf("Error while reading file: %s", err)
 		}
 
-		if !r.Strict || (r.Strict && ((AccessTime & e.MatchingTimestamp) != 0)) {
+		if e.AccessTime.After(smallestTime) && !r.Strict || (r.Strict && ((AccessTime & e.MatchingTimestamp) != 0)) {
 			r.entries = append(r.entries, TimeStampedEntry{e.AccessTime, e})
 		}
 
 		if e.ModificationTime != e.AccessTime {
-			if !r.Strict || (r.Strict && ((ModificationTime & e.MatchingTimestamp) != 0)) {
+			if e.ModificationTime.After(smallestTime) && !r.Strict || (r.Strict && ((ModificationTime & e.MatchingTimestamp) != 0)) {
 
 				r.entries = append(r.entries, TimeStampedEntry{e.ModificationTime, e})
 			}
 		}
 		if e.ChangeTime != e.ModificationTime && e.ChangeTime != e.AccessTime {
-			if !r.Strict || (r.Strict && ((ChangeTime & e.MatchingTimestamp) != 0)) {
+			if e.ChangeTime.After(smallestTime) && !r.Strict || (r.Strict && ((ChangeTime & e.MatchingTimestamp) != 0)) {
 
 				r.entries = append(r.entries, TimeStampedEntry{e.ChangeTime, e})
 			}
 		}
 		if e.CreationTime != e.ModificationTime && e.CreationTime != e.ChangeTime && e.CreationTime != e.AccessTime {
-			if !r.Strict || (r.Strict && ((CreationTime & e.MatchingTimestamp) != 0)) {
+			if e.CreationTime.After(smallestTime) && !r.Strict || (r.Strict && ((CreationTime & e.MatchingTimestamp) != 0)) {
 				r.entries = append(r.entries, TimeStampedEntry{e.CreationTime, e})
 			}
 		}

--- a/bodyfile_test.go
+++ b/bodyfile_test.go
@@ -124,3 +124,31 @@ func Test_FilterDate(t *testing.T) {
 	}
 
 }
+
+func Test_MinusOneTimestamp(t *testing.T) {
+	input := `0|\\Users\John\Desktop\My Document.docx|291779||0|0|143711|-1|-1|-1|1427897741`
+
+	r := NewReader(bytes.NewBufferString(input))
+	n, err := r.Slurp()
+	if err != nil {
+		t.Errorf("Could not slurp: %s", err)
+		return
+	}
+
+	if n > 1 {
+		t.Errorf("Wrong number of results: expected 1, got %d", n)
+		return
+	}
+
+	entry, err := r.Next()
+	if err != nil {
+		t.Errorf("Could not get the entry: %s", err)
+		return
+	}
+
+	birthTime := entry.Entry.CreationTime
+	if !entry.Time.Equal(birthTime) {
+		t.Errorf("The only entry we get should have its Time equal to the Creation time: expected %+v, got %+v", birthTime, entry.Time)
+		return
+	}
+}


### PR DESCRIPTION
This PR emulates the behavior of `mactime` more closely (see [timeliner#2](https://github.com/airbus-cert/timeliner/issues/2)).

Entry fields where the value is -1 will not be added to the `entries` array.